### PR TITLE
Fix a slow defineProperty in LogRecord

### DIFF
--- a/lib/logrecord.js
+++ b/lib/logrecord.js
@@ -12,10 +12,14 @@ function LogRecord(level, name, meta, args) {
   this.date = new Date;
 
   this._formattedMessage = null;
-  Object.defineProperty(this, 'message', {
-    get: this.getFormattedMessage.bind(this)
-  });
 }
+
+
+Object.defineProperty(LogRecord.prototype, 'message', {
+  get: function () {
+    return this.getFormattedMessage()
+  }
+});
 
 
 LogRecord.prototype.getFormattedMeta = function () {


### PR DESCRIPTION
Hello @xiao, @chaosgame, 

Please review the following commits I made in branch 'nicks/prop'.

7b3249c57b8d5792a80138796b968ac5feec77a4 (2016-04-12 16:35:57 -0700)
Fix a slow defineProperty in LogRecord

R=@xiao
R=@chaosgame
