### PR TITLE
Emit a NAME even on the root logger, even if the level is not loggable

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -186,14 +186,13 @@ Logger.prototype._log = function(level, args) {
   //
   // Event emitting plan in sequence:
   //
-  // * Emit on global key from rootLogger.
+  // * Emit on global key from rootLogger if the event is loggable.
   // * Emit a LEVEL event on the rootLogger
   // * For each name in the ancestor chain, emit an event of that name.
-  if (!this.isLoggable(level)) {
-    return
+  if (this.isLoggable(level)) {
+    rootLogger.emit('', logRecord);
   }
 
-  rootLogger.emit('', logRecord);
   rootLogger.emit(level, logRecord);
 
   var logger = this;

--- a/lib/logger_test.js
+++ b/lib/logger_test.js
@@ -2,6 +2,10 @@
 var Logger = require('./logger');
 var LogLevel = require('./level');
 
+exports.setUp = function (done) {
+  Logger._instance = null;
+  done();
+};
 
 exports.testDefaultLogLevel = function(test) {
   var logger = new Logger('test');
@@ -101,6 +105,46 @@ exports.testCloneWithNewMetadata = function(test) {
 
   test.ok(record2.meta.extraField1);
   test.ok(record2.meta.extraField2);
+
+  test.done();
+};
+
+
+exports.testFineEvent = function(test) {
+  var logger = new Logger('test');
+  var rootLogger = Logger.getSingleton();
+
+  var records = {
+    global: [],
+    fine: [],
+    test: []
+  }
+
+  rootLogger.on('', function (record) {
+    records.global.push(record)
+  })
+  rootLogger.on(LogLevel.FINE, function (record) {
+    records.fine.push(record)
+  })
+  rootLogger.on('test', function (record) {
+    records.test.push(record)
+  })
+
+
+  logger.fine('hello');
+  test.equal(0, records.global.length);
+  test.equal(1, records.fine.length);
+  test.equal(1, records.test.length);
+
+  logger.finer('hello');
+  test.equal(0, records.global.length);
+  test.equal(1, records.fine.length);
+  test.equal(2, records.test.length);
+
+  logger.info('hello');
+  test.equal(1, records.global.length);
+  test.equal(1, records.fine.length);
+  test.equal(3, records.test.length);
 
   test.done();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "logg",
-  "version" : "0.3.3",
+  "version" : "0.3.4",
   "description" : "Logging library that allows for hierarchical loggers, multiple log levels, and flexible watching of log records.",
   "keywords" : ["log", "logging", "logger", "hierarchical", "handler", "watcher"],
   "repository" : {


### PR DESCRIPTION
Hello @xiao, 

Please review the following commits I made in branch 'nicks/loggable'.

bf766e1a71ef448bce9fd921f578c20715bfbf28 (2016-04-13 17:47:35 -0700)
Emit a NAME even on the root logger, even if the level is not loggable

R=@xiao
