### PR TITLE
Stop leaking reference to Logger.info_ through LogRecord

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -181,7 +181,7 @@ Logger.prototype.log = function(level, var_args) {
  */
 Logger.prototype._log = function(level, args) {
   // Clone to prevent modifications to this Logger's internal info_ through logRecord.meta
-  var clonedInfo_ = Object.assign({}, this.info_)
+  var clonedInfo_ = Object.create(this.info_)
   var logRecord = new LogRecord(level, this.name, clonedInfo_, args);
 
   var rootLogger = Logger.getSingleton();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -180,7 +180,9 @@ Logger.prototype.log = function(level, var_args) {
  * @param {Array} args The items to log.
  */
 Logger.prototype._log = function(level, args) {
-  var logRecord = new LogRecord(level, this.name, this.info_, args);
+  // Clone to prevent modifications to this Logger's internal info_ through logRecord.meta
+  var clonedInfo_ = Object.assign({}, this.info_)
+  var logRecord = new LogRecord(level, this.name, clonedInfo_, args);
 
   var rootLogger = Logger.getSingleton();
   //

--- a/lib/logger_test.js
+++ b/lib/logger_test.js
@@ -110,6 +110,22 @@ exports.testCloneWithNewMetadata = function(test) {
 };
 
 
+exports.testPassInfoToLogRecord = function(test) {
+  var logger = new Logger('test').setMeta('loggerMeta', true);
+  var record = null;
+  logger.registerWatcher(function (logRecord) {
+    logRecord.meta.logRecordMeta = true
+    record = logRecord
+  })
+  logger.warn('Do not leak references');
+
+  test.ok(record.meta.loggerMeta)
+  test.ok(record.meta.logRecordMeta)
+  test.ok(!logger.info_.logRecordMeta)
+
+  test.done()
+}
+
 exports.testFineEvent = function(test) {
   var logger = new Logger('test');
   var rootLogger = Logger.getSingleton();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "logg",
-  "version" : "0.3.4",
+  "version" : "0.3.5",
   "description" : "Logging library that allows for hierarchical loggers, multiple log levels, and flexible watching of log records.",
   "keywords" : ["log", "logging", "logger", "hierarchical", "handler", "watcher"],
   "repository" : {


### PR DESCRIPTION
Hello @dpup, 

Please review the following commits I made in branch 'mikkot/clone-info'.

b72f39efbeb1b570ceb3785e0ea5c43ecf938b8e (2016-08-21 20:05:51 -0700)
Stop leaking reference to Logger.info_ through LogRecord

R=@dpup
